### PR TITLE
MAINT: pull in fixes to reset tuning

### DIFF
--- a/littlemcmc/base_hmc.py
+++ b/littlemcmc/base_hmc.py
@@ -189,6 +189,14 @@ class BaseHMC:
 
         return hmc_step.end.q, [stats]
 
+    def reset_tuning(self, start=None):
+        self.step_adapt.reset()
+        self.reset(start=None)
+
+    def reset(self, start=None):
+        self.tune = True
+        self.potential.reset()
+
     def warnings(self) -> List[SamplerWarning]:
         """Generate warnings from HMC sampler."""
         # list.copy() is only available in Python 3

--- a/littlemcmc/base_hmc.py
+++ b/littlemcmc/base_hmc.py
@@ -189,11 +189,13 @@ class BaseHMC:
 
         return hmc_step.end.q, [stats]
 
-    def reset_tuning(self, start=None):
+    def reset_tuning(self, start: np.ndarray = None) -> None:
+        """Reset quadpotential and step size adaptation, and begin retuning."""
         self.step_adapt.reset()
         self.reset(start=None)
 
-    def reset(self, start=None):
+    def reset(self, start: np.ndarray = None) -> None:
+        """Reset quadpotential and begin retuning."""
         self.tune = True
         self.potential.reset()
 

--- a/littlemcmc/quadpotential.py
+++ b/littlemcmc/quadpotential.py
@@ -179,16 +179,24 @@ class QuadPotentialDiagAdapt(QuadPotential):
 
         self.dtype = dtype
         self._n = n
-        self._var = np.array(initial_diag, dtype=self.dtype, copy=True)
-        self._stds = np.sqrt(initial_diag)
+
+        self._initial_mean = initial_mean
+        self._initial_diag = initial_diag
+        self._initial_weight = initial_weight
+        self.adaptation_window = adaptation_window
+        self.adaptation_window_multiplier = float(adaptation_window_multiplier)
+
+        self.reset()
+
+    def reset(self):
+        self._var = np.array(self._initial_diag, dtype=self.dtype, copy=True)
+        self._stds = np.sqrt(self._initial_diag)
         self._inv_stds = 1.0 / self._stds
         self._foreground_var = _WeightedVariance(
-            self._n, initial_mean, initial_diag, initial_weight, self.dtype
+            self._n, self._initial_mean, self._initial_diag, self._initial_weight, self.dtype
         )
         self._background_var = _WeightedVariance(self._n, dtype=self.dtype)
         self._n_samples = 0
-        self.adaptation_window = adaptation_window
-        self.adaptation_window_multiplier = float(adaptation_window_multiplier)
 
     def velocity(self, x, out=None):
         """Compute the current velocity at a position in parameter space."""

--- a/littlemcmc/quadpotential.py
+++ b/littlemcmc/quadpotential.py
@@ -133,6 +133,7 @@ class QuadPotential(object):
         return None
 
     def reset(self):
+        """Reset quadpotential adaptation routine."""
         pass
 
 
@@ -189,6 +190,7 @@ class QuadPotentialDiagAdapt(QuadPotential):
         self.reset()
 
     def reset(self):
+        """Reset quadpotential adaptation routine."""
         self._var = np.array(self._initial_diag, dtype=self.dtype, copy=True)
         self._stds = np.sqrt(self._initial_diag)
         self._inv_stds = 1.0 / self._stds

--- a/littlemcmc/sampling.py
+++ b/littlemcmc/sampling.py
@@ -59,6 +59,9 @@ def _sample_one_chain(
     else:
         iterator = range(tune + draws)
 
+    step.tune = bool(tune)
+    if hasattr(step, "reset_tuning"):
+        step.reset_tuning()
     for i in iterator:
         q, step_stats = step._astep(q)
         trace[:, i] = q

--- a/littlemcmc/step_sizes.py
+++ b/littlemcmc/step_sizes.py
@@ -47,6 +47,7 @@ class DualAverageAdaptation(object):
         self.reset()
 
     def reset(self):
+        """Reset step size adaptation routine."""
         self._log_step = np.log(self._initial_step)
         self._log_bar = self._log_step
         self._hbar = 0.0

--- a/littlemcmc/step_sizes.py
+++ b/littlemcmc/step_sizes.py
@@ -49,7 +49,7 @@ class DualAverageAdaptation(object):
     def reset(self):
         self._log_step = np.log(self._initial_step)
         self._log_bar = self._log_step
-        self._hbar = 0.
+        self._hbar = 0.0
         self._count = 1
         self._mu = np.log(10 * self._initial_step)
         self._tuned_stats = []

--- a/littlemcmc/step_sizes.py
+++ b/littlemcmc/step_sizes.py
@@ -39,15 +39,19 @@ class DualAverageAdaptation(object):
             Parameter for dual averaging. Higher values slow initial
             adaptation.
         """
-        self._log_step = np.log(initial_step)
-        self._log_bar = self._log_step
+        self._initial_step = initial_step
         self._target = target
-        self._hbar = 0.0
         self._k = k
         self._t0 = t0
-        self._count = 1
-        self._mu = np.log(10 * initial_step)
         self._gamma = gamma
+        self.reset()
+
+    def reset(self):
+        self._log_step = np.log(self._initial_step)
+        self._log_bar = self._log_step
+        self._hbar = 0.
+        self._count = 1
+        self._mu = np.log(10 * self._initial_step)
         self._tuned_stats = []
 
     def current(self, tune):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -121,7 +121,7 @@ def test_reset_tuning():
     draws = 2
     tune = 50
     chains = 2
-    start, step = lmc.sampling.init_nuts(chains=chains)
+    start, step = lmc.init_nuts(logp_dlogp_func=logp_dlogp_func, model_ndim=1, chains=chains)
     cores = 1
     lmc.sample(
         logp_dlogp_func, draws=draws, tune=tune, chains=chains, step=step, start=start, cores=cores

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -116,7 +116,7 @@ def test_nuts_recovers_1d_normal():
     assert np.allclose(np.std(trace), 1, atol=1)
 
 
-def test_reset_tuning(self):
+def test_reset_tuning():
     model_ndim = 1
     draws = 2
     tune = 50

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -123,6 +123,8 @@ def test_reset_tuning(self):
     chains = 2
     start, step = lmc.sampling.init_nuts(chains=chains)
     cores = 1
-    lmc.sample(logp_dlogp_func, draws=draws, tune=tune, chains=chains, step=step, start=start, cores=cores)
+    lmc.sample(
+        logp_dlogp_func, draws=draws, tune=tune, chains=chains, step=step, start=start, cores=cores
+    )
     assert step.potential._n_samples == tune
     assert step.step_adapt._count == tune + 1

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -124,7 +124,14 @@ def test_reset_tuning():
     start, step = lmc.init_nuts(logp_dlogp_func=logp_dlogp_func, model_ndim=1)
     cores = 1
     lmc.sample(
-        logp_dlogp_func, draws=draws, tune=tune, chains=chains, step=step, start=start, cores=cores
+        logp_dlogp_func,
+        model_ndim,
+        draws=draws,
+        tune=tune,
+        chains=chains,
+        step=step,
+        start=start,
+        cores=cores,
     )
     assert step.potential._n_samples == tune
     assert step.step_adapt._count == tune + 1

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -121,7 +121,7 @@ def test_reset_tuning():
     draws = 2
     tune = 50
     chains = 2
-    start, step = lmc.init_nuts(logp_dlogp_func=logp_dlogp_func, model_ndim=1, chains=chains)
+    start, step = lmc.init_nuts(logp_dlogp_func=logp_dlogp_func, model_ndim=1)
     cores = 1
     lmc.sample(
         logp_dlogp_func, draws=draws, tune=tune, chains=chains, step=step, start=start, cores=cores

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -114,3 +114,15 @@ def test_nuts_recovers_1d_normal():
 
     assert np.allclose(np.mean(trace), 0, atol=1)
     assert np.allclose(np.std(trace), 1, atol=1)
+
+
+def test_reset_tuning(self):
+    model_ndim = 1
+    draws = 2
+    tune = 50
+    chains = 2
+    start, step = lmc.sampling.init_nuts(chains=chains)
+    cores = 1
+    lmc.sample(logp_dlogp_func, draws=draws, tune=tune, chains=chains, step=step, start=start, cores=cores)
+    assert step.potential._n_samples == tune
+    assert step.step_adapt._count == tune + 1


### PR DESCRIPTION
Closes #67.

The upstream PR (https://github.com/pymc-devs/pymc3/pull/3941/files) also makes some changes to `QuadPotentialDiagAdaptGrad`, which `littlemcmc` does not have, so we leave out those changes. Everything else should be pulled in, though.